### PR TITLE
Improve library retry and refresh UX

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -175,6 +175,12 @@ class Converter:
         self._segments: int = max(1, min(8, self.concurrency))  # parallélisme segments yt-dlp
         self.auto_best: bool = self.output_mode == "auto"
         self.append_to_existing_playlist: bool = bool(self.config.get("append_to_existing_playlist", False))
+        try:
+            self.replace_manifest_track_idx = max(
+                0, int(self.config.get("replace_manifest_track_idx") or 0)
+            )
+        except (TypeError, ValueError):
+            self.replace_manifest_track_idx = 0
 
         # pour la M3U
         self._made_files_lock = threading.Lock()
@@ -614,7 +620,14 @@ class Converter:
             if self.append_to_existing_playlist and previous:
                 previous_tracks = previous.get("tracks")
                 if isinstance(previous_tracks, list):
-                    tracks = self._merge_manifest_tracks(previous_tracks, tracks)
+                    if self.replace_manifest_track_idx and len(tracks) == 1:
+                        tracks = self._replace_manifest_track(
+                            previous_tracks,
+                            tracks[0],
+                            self.replace_manifest_track_idx,
+                        )
+                    else:
+                        tracks = self._merge_manifest_tracks(previous_tracks, tracks)
             manifest = build_manifest(
                 playlist_name=str(playlist_name),
                 playlist_dir=out_dir,
@@ -639,6 +652,42 @@ class Converter:
         if title or artists:
             return f"title:{artists}|{title}"
         return ""
+
+    @staticmethod
+    def _replace_manifest_track(
+        previous_tracks: list,
+        incoming_track: dict,
+        target_idx: int,
+    ) -> list[dict]:
+        """Replace one retry target by its original manifest index."""
+        replacement = dict(incoming_track)
+        replacement["idx"] = target_idx
+        merged: list[dict] = []
+        replaced = False
+
+        for track in previous_tracks:
+            if not isinstance(track, dict):
+                continue
+            try:
+                current_idx = int(track.get("idx") or 0)
+            except (TypeError, ValueError):
+                current_idx = 0
+            if current_idx != target_idx:
+                merged.append(dict(track))
+                continue
+
+            updated = dict(track)
+            for stale_key in ("error", "suggested_url", "match"):
+                updated.pop(stale_key, None)
+            updated.update(replacement)
+            updated["idx"] = target_idx
+            merged.append(updated)
+            replaced = True
+
+        if not replaced:
+            merged.append(replacement)
+        merged.sort(key=lambda track: int(track.get("idx") or 0))
+        return merged
 
     @classmethod
     def _merge_manifest_tracks(cls, previous_tracks: list, new_tracks: list[dict]) -> list[dict]:

--- a/qt_app.py
+++ b/qt_app.py
@@ -253,6 +253,22 @@ QPushButton#ghost:hover {
   background: #242424;
   color: #f5f5f5;
 }
+QPushButton#attentionAction, QPushButton#attentionActionMuted {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 5px 8px;
+}
+QPushButton#attentionAction {
+  color: #1ed760;
+}
+QPushButton#attentionActionMuted {
+  color: #b3b3b3;
+}
+QPushButton#attentionAction:hover, QPushButton#attentionActionMuted:hover {
+  background: #242424;
+  color: #f5f5f5;
+}
 QPushButton#libraryAction {
   background: #181818;
   border: none;
@@ -693,10 +709,16 @@ class NeedsAttentionDialog(QDialog):
                 next_action = "Retry"
             else:
                 next_action = "Open"
-            action_item = QTableWidgetItem(next_action)
-            action_item.setForeground(QColor("#1ed760" if item.get("candidate_url") else "#b3b3b3"))
-            action_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-            self.table.setItem(row, 3, action_item)
+            action_btn = QPushButton(next_action)
+            action_btn.setObjectName(
+                "attentionAction" if item.get("candidate_url") else "attentionActionMuted"
+            )
+            action_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            action_btn.setToolTip(f"{next_action} this track")
+            action_btn.clicked.connect(
+                lambda _checked=False, selected_row=row: self._activate_row(selected_row)
+            )
+            self.table.setCellWidget(row, 3, action_btn)
 
         if self._items:
             self.table.selectRow(0)
@@ -719,6 +741,12 @@ class NeedsAttentionDialog(QDialog):
             return None
         row = rows[0].row()
         return dict(self._items[row]) if 0 <= row < len(self._items) else None
+
+    def _activate_row(self, row: int):
+        if not 0 <= row < len(self._items):
+            return
+        self.table.selectRow(row)
+        self.accept()
 
 
 class ArtworkWidget(QWidget):
@@ -1189,6 +1217,8 @@ class QtMusic2MP3Window(QMainWindow):
 
         self._thread: QThread | None = None
         self._worker: ConverterWorker | None = None
+        self._retry_context: dict | None = None
+        self._retry_tmp_csv: str | None = None
         self._load_thread: QThread | None = None
         self._load_worker: PlaylistLoadWorker | None = None
         self._cleanup_thread: QThread | None = None
@@ -1367,11 +1397,13 @@ class QtMusic2MP3Window(QMainWindow):
         self.sync_all_btn.clicked.connect(self._sync_all_library_playlists)
         library_actions.addWidget(self.sync_all_btn, 0, 1)
 
-        self.library_scan_btn = QPushButton("Rescan folders")
+        self.library_scan_btn = QPushButton("Refresh library")
         self.library_scan_btn.setObjectName("libraryAction")
         self.library_scan_btn.setMinimumHeight(28)
-        self.library_scan_btn.setToolTip("Rescan the library folder for local playlists")
-        self.library_scan_btn.clicked.connect(self._scan_library_root)
+        self.library_scan_btn.setToolTip(
+            "Reload playlists and local files from the library folder (no download)"
+        )
+        self.library_scan_btn.clicked.connect(self._refresh_library)
         library_actions.addWidget(self.library_scan_btn, 1, 0)
 
         self.library_cleanup_btn = QPushButton("Clean library")
@@ -2211,8 +2243,27 @@ class QtMusic2MP3Window(QMainWindow):
 
     # ── Library ────────────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _dialog_start_directory(*candidates: str | os.PathLike | None) -> str:
+        """Return the first existing folder so macOS never opens in a stale temp path."""
+        for candidate in candidates:
+            if not candidate:
+                continue
+            try:
+                path = Path(candidate).expanduser()
+            except (TypeError, ValueError):
+                continue
+            if path.is_dir():
+                return str(path)
+        return str(Path.home())
+
     def _choose_library_root(self):
-        initial = self.library_root or self.output_folder or str(Path.home() / "Music")
+        initial = self._dialog_start_directory(
+            self.library_root,
+            self.output_folder,
+            Path.home() / "Music",
+            Path.home(),
+        )
         path = QFileDialog.getExistingDirectory(self, "Select Library Root", initial)
         if not path:
             return
@@ -2267,6 +2318,24 @@ class QtMusic2MP3Window(QMainWindow):
             self._update_hero()
             self._populate_table_for_selection()
         self._update_library_actions()
+
+    def _refresh_library(self, _checked: bool = False):
+        """Reload the local library index without syncing remote sources."""
+        root = self.library_root
+        if not root or not os.path.isdir(root):
+            self._scan_library_root(show_empty=True)
+            return
+
+        selected = self._selected_library_manifest()
+        selected_dir = str(selected.get("playlist_dir") or "") if selected else None
+        self._scan_library_root(show_empty=True, select_playlist_dir=selected_dir)
+
+        count = len(self.library_items)
+        suffix = "playlist" if count == 1 else "playlists"
+        self.global_progress.setRange(0, 100)
+        self.global_progress.setValue(100)
+        self.footer_eta_lbl.setText("")
+        self._set_footer_state("done", f"Library refreshed · {count} {suffix}")
 
     def _refresh_needs_attention(self):
         self._attention_items = collect_attention_items(self.library_items)
@@ -3137,6 +3206,7 @@ class QtMusic2MP3Window(QMainWindow):
 
     @Slot(str)
     def _on_done(self, out_dir: str):
+        retry_context = self._retry_context
         sync_manifest = self._sync_target_manifest
         appended_to_library = self._append_to_library_manifest is not None
         self.last_output_dir = out_dir
@@ -3173,10 +3243,24 @@ class QtMusic2MP3Window(QMainWindow):
             else:
                 self._record_sync_queue_result(sync_manifest, "done")
         self._scan_library_root(show_empty=False, select_playlist_dir=out_dir)
+        if retry_context and not self._was_cancelled:
+            title = str(retry_context.get("title") or "Track")
+            if retry_context.get("succeeded") and not retry_context.get("failed"):
+                self._set_footer_state("done", f"Retry successful · {title}")
+            else:
+                self._set_footer_state("warning", f"Retry failed · {title}")
 
     @Slot(str)
     def _on_failed(self, error_text: str):
         self._timer.stop()
+        if self._retry_context:
+            self._retry_context["failed"] = True
+            title = str(self._retry_context.get("title") or "Track")
+            out_dir = str(self._retry_context.get("out_dir") or "")
+            self._set_footer_state("error", f"Retry failed · {title}")
+            self._scan_library_root(show_empty=False, select_playlist_dir=out_dir)
+            QMessageBox.critical(self, "Retry failed", error_text)
+            return
         self._set_footer_state("error", "failed")
         if self._sync_queue_active and self._sync_target_manifest:
             self._record_sync_queue_result(self._sync_target_manifest, "failed", error_text)
@@ -3190,6 +3274,14 @@ class QtMusic2MP3Window(QMainWindow):
             self._thread.deleteLater()
             self._thread = None
         self._worker = None
+        retry_tmp_csv = self._retry_tmp_csv
+        self._retry_tmp_csv = None
+        self._retry_context = None
+        if retry_tmp_csv:
+            try:
+                Path(retry_tmp_csv).unlink(missing_ok=True)
+            except OSError as exc:
+                log.warning("Could not remove retry CSV %s: %s", retry_tmp_csv, exc)
         self._sync_target_manifest = None
         self._restyle(self.stop_btn, "danger")  # restore normal stop style
         self._set_ui_enabled(True)
@@ -3482,6 +3574,14 @@ class QtMusic2MP3Window(QMainWindow):
         close_btn.clicked.connect(dlg.accept)
         btn_row.addWidget(close_btn)
         layout.addLayout(btn_row)
+
+        def _focus_url_input():
+            url_input.setFocus(Qt.FocusReason.OtherFocusReason)
+            url_input.setCursorPosition(len(url_input.text()))
+
+        # The read-only error details appear first in the dialog and otherwise
+        # receive initial focus, leaving the editable URL field without a caret.
+        QTimer.singleShot(0, _focus_url_input)
         dlg.exec()
 
     def _open_soulseek_search_dialog(self, track_t: dict):
@@ -3619,6 +3719,10 @@ class QtMusic2MP3Window(QMainWindow):
                 })
         except Exception as e:
             log.error("Retry: failed to create temp CSV: %s", e)
+            try:
+                Path(tmp_csv).unlink(missing_ok=True)
+            except OSError:
+                pass
             QMessageBox.critical(self, "Retry error", str(e))
             return
 
@@ -3631,6 +3735,16 @@ class QtMusic2MP3Window(QMainWindow):
         retry_config = self.config.copy()
         retry_config["incremental_update"] = False
         retry_config["append_to_existing_playlist"] = True
+        retry_config["replace_manifest_track_idx"] = idx
+        title = str(track_t.get("title") or f"Track {idx}")
+        self._retry_context = {
+            "idx": idx,
+            "title": title,
+            "out_dir": out_dir,
+            "succeeded": False,
+            "failed": False,
+        }
+        self._retry_tmp_csv = tmp_csv
         # Use out_dir directly as output folder with no playlist subdirectory
         self._thread = QThread(self)
         self._worker = ConverterWorker(
@@ -3638,7 +3752,7 @@ class QtMusic2MP3Window(QMainWindow):
             tmp_csv,
             out_dir,          # output_folder = the already-named playlist dir
             None,             # playlist_hint = None so no subdir is created
-            self.loaded_source_info,
+            None,             # preserve the existing manifest playlist source
         )
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.run)
@@ -3652,12 +3766,23 @@ class QtMusic2MP3Window(QMainWindow):
         self._restyle(self.stop_btn, "dangerActive")
         self.stop_btn.setEnabled(True)
         self._set_ui_enabled(False)
+        self._was_cancelled = False
+        self._total_tracks = 1
+        self.global_progress.setRange(0, 100)
+        self.global_progress.setValue(0)
+        self.footer_eta_lbl.setText("")
+        self._set_footer_state("running", f"Retrying · {title}")
         self._started_at = time.time()
         self._timer.start(1000)
         self._thread.start()
         log.info("Retry track %d with URL: %s", idx, url)
 
     def _on_retry_item(self, target_idx: int, ev: str, data_obj: object):
+        if self._retry_context:
+            if ev == "done":
+                self._retry_context["succeeded"] = True
+            elif ev == "error":
+                self._retry_context["failed"] = True
         if isinstance(data_obj, dict):
             data = dict(data_obj)
             if "idx" in data:
@@ -3824,8 +3949,14 @@ class QtMusic2MP3Window(QMainWindow):
             self.action_output_lbl.setToolTip("Choose output root folder")
 
     def _choose_output_folder(self):
+        initial = self._dialog_start_directory(
+            self.output_folder,
+            self.library_root,
+            Path.home() / "Downloads",
+            Path.home(),
+        )
         path = QFileDialog.getExistingDirectory(
-            self, "Select Output Folder", str(Path.home() / "Downloads")
+            self, "Select Output Folder", initial
         )
         if not path:
             return

--- a/tests/test_converter_helpers.py
+++ b/tests/test_converter_helpers.py
@@ -767,6 +767,97 @@ class ConverterHelpersTests(unittest.TestCase):
                 ["Artist - Old.mp3", "Artist - New.mp3"],
             )
 
+    def test_retry_replaces_original_manifest_track_even_when_url_changes(self):
+        class NoDownloadConverter(Converter):
+            def _run_ytdlp_stream(self, *args, **kwargs):
+                return 0
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            playlist_dir = root / "Retry playlist"
+            existing_manifest = build_manifest(
+                playlist_name="Retry playlist",
+                playlist_dir=playlist_dir,
+                source={
+                    "type": "spotify",
+                    "url": "https://open.spotify.com/playlist/retry",
+                    "name": "Retry playlist",
+                },
+                settings={"safe_search": True},
+                tracks=[
+                    {
+                        "idx": 7,
+                        "title": "Blocked track",
+                        "artists": "Artist",
+                        "source_url": "https://old.example/blocked",
+                        "file": "",
+                        "status": "failed",
+                        "format": "MP3",
+                        "error": "Download blocked",
+                        "suggested_url": "https://youtu.be/old-candidate",
+                        "match": {"url": "https://youtu.be/old-candidate"},
+                    },
+                    {
+                        "idx": 8,
+                        "title": "Existing track",
+                        "artists": "Artist",
+                        "source_url": "https://example.com/existing",
+                        "file": "Artist - Existing track.mp3",
+                        "status": "done",
+                        "format": "MP3",
+                    },
+                ],
+            )
+            write_manifest(playlist_dir, existing_manifest)
+
+            csv_path = root / "retry.csv"
+            with csv_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=[
+                        "Track Name",
+                        "Artist Name(s)",
+                        "Album Name",
+                        "Duration (ms)",
+                        "Source URL",
+                        "Track URI",
+                    ],
+                )
+                writer.writeheader()
+                writer.writerow({
+                    "Track Name": "Blocked track",
+                    "Artist Name(s)": "Artist",
+                    "Album Name": "",
+                    "Duration (ms)": "180000",
+                    "Source URL": "https://youtu.be/manual-retry",
+                    "Track URI": "",
+                })
+
+            conv = NoDownloadConverter(config={
+                "safe_search": True,
+                "generate_m3u": False,
+                "incremental_update": False,
+                "append_to_existing_playlist": True,
+                "replace_manifest_track_idx": 7,
+            })
+            result_dir = Path(conv.convert_from_csv(
+                str(csv_path),
+                str(playlist_dir),
+                None,
+                source_info=None,
+            ))
+            manifest = json.loads((result_dir / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+
+            self.assertEqual(manifest["track_count"], 2)
+            self.assertEqual(manifest["source"]["url"], "https://open.spotify.com/playlist/retry")
+            self.assertEqual([track["idx"] for track in manifest["tracks"]], [7, 8])
+            retried = manifest["tracks"][0]
+            self.assertEqual(retried["status"], "done")
+            self.assertEqual(retried["source_url"], "https://youtu.be/manual-retry")
+            self.assertNotIn("error", retried)
+            self.assertNotIn("suggested_url", retried)
+            self.assertNotIn("match", retried)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qt_app_smoke.py
+++ b/tests/test_qt_app_smoke.py
@@ -90,6 +90,12 @@ class _FakeDeleteMessageBox:
 
 
 class QtAppSmokeTests(unittest.TestCase):
+    def setUp(self):
+        self._config_dir = tempfile.TemporaryDirectory()
+        test_config = Path(self._config_dir.name) / "config.json"
+        self._config_patch = patch.object(qt_app, "CONFIG_FILE", str(test_config))
+        self._config_patch.start()
+
     def _make_window(self, root: Path):
         app = _app()
         original_load_config = qt_app.load_config
@@ -117,6 +123,8 @@ class QtAppSmokeTests(unittest.TestCase):
 
     def tearDown(self):
         _app().processEvents()
+        self._config_patch.stop()
+        self._config_dir.cleanup()
 
     def test_main_window_scans_manifest_library(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -281,6 +289,140 @@ class QtAppSmokeTests(unittest.TestCase):
                 window.close()
                 window.deleteLater()
 
+    def test_retry_success_refreshes_manifest_attention_and_feedback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            playlist_dir = root / "Retry playlist"
+            failed_manifest = build_manifest(
+                playlist_name="Retry playlist",
+                playlist_dir=playlist_dir,
+                source={
+                    "type": "spotify",
+                    "url": "https://open.spotify.com/playlist/retry",
+                    "name": "Retry playlist",
+                },
+                settings={},
+                tracks=[{
+                    "idx": 7,
+                    "title": "Blocked track",
+                    "artists": "Artist",
+                    "status": "failed",
+                    "file": "",
+                    "error": "Download blocked",
+                }],
+            )
+            write_manifest(playlist_dir, failed_manifest)
+            window = self._make_window(root)
+            try:
+                self.assertEqual(len(window._attention_items), 1)
+                audio_path = playlist_dir / "Artist - Blocked track.mp3"
+                audio_path.write_bytes(b"audio")
+                done_manifest = build_manifest(
+                    playlist_name="Retry playlist",
+                    playlist_dir=playlist_dir,
+                    source=failed_manifest["source"],
+                    settings={},
+                    tracks=[{
+                        "idx": 7,
+                        "title": "Blocked track",
+                        "artists": "Artist",
+                        "status": "done",
+                        "file": audio_path.name,
+                        "format": "MP3",
+                    }],
+                    previous_manifest=failed_manifest,
+                )
+                write_manifest(playlist_dir, done_manifest)
+                window._retry_context = {
+                    "idx": 7,
+                    "title": "Blocked track",
+                    "out_dir": str(playlist_dir),
+                    "succeeded": True,
+                    "failed": False,
+                }
+                window._total_tracks = 1
+                window._started_at = time.time()
+
+                window._on_done(str(playlist_dir))
+
+                self.assertEqual(len(window._attention_items), 0)
+                self.assertEqual(window.needs_attention_btn.text(), "Needs attention · 0")
+                self.assertEqual(
+                    window.footer_status_lbl.text(),
+                    "Retry successful · Blocked track",
+                )
+                self.assertEqual(window.table.item(0, 4).text(), "● done")
+            finally:
+                window.close()
+                window.deleteLater()
+
+    def test_retry_failure_stays_in_attention_with_clear_feedback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            playlist_dir = root / "Retry playlist"
+            failed_manifest = build_manifest(
+                playlist_name="Retry playlist",
+                playlist_dir=playlist_dir,
+                source={
+                    "type": "spotify",
+                    "url": "https://open.spotify.com/playlist/retry",
+                    "name": "Retry playlist",
+                },
+                settings={},
+                tracks=[{
+                    "idx": 7,
+                    "title": "Blocked track",
+                    "artists": "Artist",
+                    "status": "failed",
+                    "file": "",
+                    "error": "The manual URL is unavailable",
+                }],
+            )
+            write_manifest(playlist_dir, failed_manifest)
+            window = self._make_window(root)
+            try:
+                window._retry_context = {
+                    "idx": 7,
+                    "title": "Blocked track",
+                    "out_dir": str(playlist_dir),
+                    "succeeded": False,
+                    "failed": True,
+                }
+                window._total_tracks = 1
+                window._started_at = time.time()
+
+                window._on_done(str(playlist_dir))
+
+                self.assertEqual(len(window._attention_items), 1)
+                self.assertEqual(window.needs_attention_btn.text(), "Needs attention · 1")
+                self.assertEqual(
+                    window.footer_status_lbl.text(),
+                    "Retry failed · Blocked track",
+                )
+                self.assertIn(7, window._errors)
+            finally:
+                window.close()
+                window.deleteLater()
+
+    def test_retry_worker_cleanup_removes_temporary_csv(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            retry_csv = root / "retry.csv"
+            retry_csv.write_text("Track Name\nTrack\n", encoding="utf-8")
+            window = self._make_window(root)
+            try:
+                window._retry_tmp_csv = str(retry_csv)
+                window._retry_context = {"title": "Track"}
+
+                window._on_worker_finished()
+
+                self.assertFalse(retry_csv.exists())
+                self.assertIsNone(window._retry_tmp_csv)
+                self.assertIsNone(window._retry_context)
+            finally:
+                window.close()
+                window.deleteLater()
+
     def test_local_scan_button_chooses_root_and_selects_playlist(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -370,6 +512,28 @@ class QtAppSmokeTests(unittest.TestCase):
                 window.close()
                 window.deleteLater()
 
+    def test_choose_library_root_ignores_stale_temporary_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stale = root / "deleted" / "library"
+            window = self._make_window(root)
+            window.library_root = str(stale)
+            window.output_folder = str(stale)
+            expected = Path.home() / "Music"
+            if not expected.is_dir():
+                expected = Path.home()
+            try:
+                with patch(
+                    "qt_app.QFileDialog.getExistingDirectory",
+                    return_value="",
+                ) as choose:
+                    window._choose_library_root()
+
+                self.assertEqual(Path(choose.call_args.args[2]), expected)
+            finally:
+                window.close()
+                window.deleteLater()
+
     def test_library_actions_use_explicit_labels(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -381,10 +545,47 @@ class QtAppSmokeTests(unittest.TestCase):
                 self.assertEqual(window.sync_all_btn.toolTip(), "Sync all playlists: no playlists with a saved URL")
                 self.assertGreaterEqual(window.sync_btn.minimumHeight(), 28)
                 self.assertGreaterEqual(window.sync_all_btn.minimumHeight(), 28)
-                self.assertEqual(window.library_scan_btn.text(), "Rescan folders")
-                self.assertEqual(window.library_scan_btn.toolTip(), "Rescan the library folder for local playlists")
+                self.assertEqual(window.library_scan_btn.text(), "Refresh library")
+                self.assertIn("no download", window.library_scan_btn.toolTip())
                 self.assertEqual(window.library_cleanup_btn.text(), "Clean library")
                 self.assertIn("orphan files", window.library_cleanup_btn.toolTip())
+            finally:
+                window.close()
+                window.deleteLater()
+
+    def test_refresh_library_reports_result_and_keeps_selection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / "First"
+            second = root / "Second"
+            first.mkdir()
+            second.mkdir()
+            (first / "One.mp3").write_bytes(b"audio")
+            (second / "Two.mp3").write_bytes(b"audio")
+
+            window = self._make_window(root)
+            try:
+                second_idx = next(
+                    i
+                    for i, item in enumerate(window.library_items)
+                    if Path(item["playlist_dir"]).name == "Second"
+                )
+                window._on_playlist_item_clicked(second_idx)
+
+                (root / "Third").mkdir()
+                (root / "Third" / "Three.mp3").write_bytes(b"audio")
+                window.library_scan_btn.click()
+                _app().processEvents()
+
+                selected = window._selected_library_manifest()
+                self.assertIsNotNone(selected)
+                self.assertEqual(Path(selected["playlist_dir"]).name, "Second")
+                self.assertEqual(len(window.library_items), 3)
+                self.assertEqual(
+                    window.footer_status_lbl.text(),
+                    "Library refreshed · 3 playlists",
+                )
+                self.assertFalse(window.footer_bar.isHidden())
             finally:
                 window.close()
                 window.deleteLater()
@@ -483,20 +684,75 @@ class QtAppSmokeTests(unittest.TestCase):
                 window.close()
                 window.deleteLater()
 
+    def test_error_dialog_focuses_manual_url_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            window = self._make_window(Path(tmp))
+            observed = {}
+
+            def fake_exec(dialog):
+                dialog.show()
+                _app().processEvents()
+                url_input = next(
+                    edit
+                    for edit in dialog.findChildren(qt_app.QLineEdit)
+                    if "YouTube URL" in edit.placeholderText()
+                )
+                observed["focused"] = url_input.hasFocus()
+                observed["cursor_position"] = url_input.cursorPosition()
+                observed["text_length"] = len(url_input.text())
+                dialog.close()
+                return qt_app.QDialog.DialogCode.Rejected
+
+            try:
+                window._errors[1] = (
+                    "Track",
+                    "No reliable match was found.",
+                    "https://youtu.be/candidate",
+                    {},
+                    str(Path(tmp)),
+                )
+                with patch.object(qt_app.QDialog, "exec", new=fake_exec):
+                    window._show_error_dialog(1)
+
+                self.assertTrue(observed["focused"])
+                self.assertEqual(observed["cursor_position"], observed["text_length"])
+            finally:
+                window.close()
+                window.deleteLater()
+
     def test_needs_attention_dialog_exposes_selected_item(self):
-        dialog = qt_app.NeedsAttentionDialog([{
-            "playlist_name": "Playlist",
-            "track_idx": 4,
-            "title": "Track",
-            "artists": "Artist",
-            "kind": "failed",
-            "issue": "Download failed",
-            "error": "yt-dlp failed",
-            "candidate_url": "https://youtu.be/retry",
-        }])
+        _app()
+        dialog = qt_app.NeedsAttentionDialog([
+            {
+                "playlist_name": "First playlist",
+                "track_idx": 4,
+                "title": "First track",
+                "artists": "Artist",
+                "kind": "failed",
+                "issue": "Download failed",
+                "error": "yt-dlp failed",
+                "candidate_url": "",
+            },
+            {
+                "playlist_name": "Retry playlist",
+                "track_idx": 7,
+                "title": "Retry track",
+                "artists": "Artist",
+                "kind": "failed",
+                "issue": "Download blocked",
+                "error": "yt-dlp failed",
+                "candidate_url": "https://youtu.be/retry",
+            },
+        ])
         try:
-            self.assertEqual(dialog.selected_item()["track_idx"], 4)
-            self.assertEqual(dialog.table.item(0, 3).text(), "Retry")
+            retry_btn = dialog.table.cellWidget(1, 3)
+            self.assertIsInstance(retry_btn, qt_app.QPushButton)
+            self.assertEqual(retry_btn.text(), "Retry")
+
+            retry_btn.click()
+
+            self.assertEqual(dialog.result(), qt_app.QDialog.DialogCode.Accepted)
+            self.assertEqual(dialog.selected_item()["track_idx"], 7)
         finally:
             dialog.close()
             dialog.deleteLater()


### PR DESCRIPTION
## What changed

- make `Retry`, `Review`, and `Open` real clickable actions in **Needs attention**
- focus the manual URL field when the retry dialog opens
- replace the original manifest track by index after a retry, even when the URL changes
- preserve playlist source metadata, refresh the attention count, and show explicit retry feedback
- rename `Rescan folders` to `Refresh library` with visible scan results
- ignore stale temporary folders when opening macOS directory pickers
- isolate Qt smoke-test configuration from the real user config
- clean up temporary retry CSV files

## Why

The retry text looked interactive but was only a table item. Successful retries could also be merged as new manifest entries when their manual URL differed from the failed source URL, leaving the original failure in **Needs attention**. Stale test paths could leak into the macOS folder picker and open it inside `/var/folders/.../T`.

## Impact

The complete **Needs attention → Retry → download → manifest → refreshed counter** flow is now reliable and gives clear success or failure feedback. Library refresh and folder selection are also more explicit.

## Validation

- user-validated real retry with a YouTube URL
- `QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests`
- 121 tests passed, 2 skipped
- `git diff --check`